### PR TITLE
Fix/login issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,18 @@
             <version>0.12.5</version>
         </dependency>
         <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>

--- a/src/main/java/com/dev/aalto/paycraft/config/SecurityConfig.java
+++ b/src/main/java/com/dev/aalto/paycraft/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
     @Bean
     public UrlBasedCorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.addAllowedOrigin("*"); // Allows all origins (adjust it if you need to)
+        configuration.addAllowedOrigin("http://localhost:5173"); // Allows all origins (adjust it if you need to)
         configuration.addAllowedMethod("*"); // Allows all methods
         configuration.addAllowedHeader("*"); // Allows all headers.
         configuration.setAllowCredentials(true);

--- a/src/main/java/com/dev/aalto/paycraft/controller/AuthenticationController.java
+++ b/src/main/java/com/dev/aalto/paycraft/controller/AuthenticationController.java
@@ -1,6 +1,5 @@
 package com.dev.aalto.paycraft.controller;
 
-import com.dev.aalto.paycraft.constant.PayCraftConstant;
 import com.dev.aalto.paycraft.dto.*;
 import com.dev.aalto.paycraft.service.IAuthenticationService;
 import com.dev.aalto.paycraft.service.ICreateAccountService;

--- a/src/main/java/com/dev/aalto/paycraft/service/JwtService.java
+++ b/src/main/java/com/dev/aalto/paycraft/service/JwtService.java
@@ -3,6 +3,7 @@ package com.dev.aalto.paycraft.service;
 import com.dev.aalto.paycraft.entity.UserAccount;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
+import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -27,9 +28,13 @@ public class JwtService {
     private SecretKey SECRET_KEY;
     private static final long EXPIRATION_TIME = 86400000; //24hrs
 
-    public void JWTService() {
+    @PostConstruct
+    public void init() {
+        if (SECRET_STRING == null) {
+            throw new IllegalStateException("SECRET_STRING is not configured");
+        }
         byte[] keyByte = Base64.getDecoder().decode(SECRET_STRING.getBytes(StandardCharsets.UTF_8));
-        this.SECRET_KEY = new SecretKeySpec(keyByte,"HmacSHA256");
+        this.SECRET_KEY = new SecretKeySpec(keyByte, "HmacSHA256");
     }
 
     public String createJWT(UserAccount user) { return  generateToken(user); }

--- a/src/main/java/com/dev/aalto/paycraft/service/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/com/dev/aalto/paycraft/service/impl/AuthenticationServiceImpl.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import static com.dev.aalto.paycraft.constant.PayCraftConstant.*;
 
 @Slf4j @Service @RequiredArgsConstructor
-public class IAuthenticationServiceImpl implements IAuthenticationService {
+public class AuthenticationServiceImpl implements IAuthenticationService {
     private final UserAccountRepository userRepository;
     private final AuthTokenRepository tokenRepository;
     private final JwtService jwtService;

--- a/src/main/java/com/dev/aalto/paycraft/service/impl/CreateAccountServiceImpl.java
+++ b/src/main/java/com/dev/aalto/paycraft/service/impl/CreateAccountServiceImpl.java
@@ -11,7 +11,6 @@ import com.dev.aalto.paycraft.repository.CompanyAccountRepository;
 import com.dev.aalto.paycraft.repository.UserAccountRepository;
 import com.dev.aalto.paycraft.service.ICreateAccountService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -25,7 +24,6 @@ public class CreateAccountServiceImpl implements ICreateAccountService {
 
     @Override
     public DefaultApiResponse<UserAccountDto> createUserAccount(CreateAccountDto request) {
-
         DefaultApiResponse<UserAccountDto> response = new DefaultApiResponse<>();
         UserAccount userAccount = UserAccountMapper.maptoUserAccount(new UserAccount(), extractUserAccount(request));
         verifyRecord(userAccount);

--- a/src/main/java/com/dev/aalto/paycraft/service/impl/CreateAccountServiceImpl.java
+++ b/src/main/java/com/dev/aalto/paycraft/service/impl/CreateAccountServiceImpl.java
@@ -11,6 +11,8 @@ import com.dev.aalto.paycraft.repository.CompanyAccountRepository;
 import com.dev.aalto.paycraft.repository.UserAccountRepository;
 import com.dev.aalto.paycraft.service.ICreateAccountService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import static com.dev.aalto.paycraft.constant.PayCraftConstant.ONBOARD_SUCCESS;
@@ -19,6 +21,7 @@ import static com.dev.aalto.paycraft.constant.PayCraftConstant.ONBOARD_SUCCESS;
 public class CreateAccountServiceImpl implements ICreateAccountService {
     private final UserAccountRepository userAccountRepository;
     private final CompanyAccountRepository companyAccountRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public DefaultApiResponse<UserAccountDto> createUserAccount(CreateAccountDto request) {
@@ -26,7 +29,7 @@ public class CreateAccountServiceImpl implements ICreateAccountService {
         DefaultApiResponse<UserAccountDto> response = new DefaultApiResponse<>();
         UserAccount userAccount = UserAccountMapper.maptoUserAccount(new UserAccount(), extractUserAccount(request));
         verifyRecord(userAccount);
-        createAccount(userAccount, request.getPassword());
+        userAccount.setPassword(passwordEncoder.encode(request.getPassword()));
         /* create user account during onboarding */
         userAccountRepository.save(userAccount);
         /* create company account during onboarding */
@@ -79,7 +82,4 @@ public class CreateAccountServiceImpl implements ICreateAccountService {
         return companyAccount;
     }
 
-    private void createAccount(UserAccount userAccount, String password){
-        userAccount.setPassword(password + "weuihwoei"); //todo: encrypt password
-    }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,7 +22,7 @@ logging:
       springframework:
         security: DEBUG
 
-secret-string: ${SECRET_STRING}
+secret-string: ${SECRET_STRING:PAYHFUKNSF09839FELIKS9348J39GHIUEWFJR9EF089WUJ4FNR9HG738UJW4WOLLSTONECRAFT}
 
 server:
   port: 6020


### PR DESCRIPTION
#### **Issue**
The `JwtService` was throwing a `NullPointerException` due to `SECRET_STRING` being `null` when the service was initialized.

#### **Fix**
- Moved the `SECRET_KEY` initialization to a `@PostConstruct` method to ensure `SECRET_STRING` is injected before use.
- Added a null check to throw a clear error if `SECRET_STRING` is not configured.